### PR TITLE
Integrate CircleCI for testing and linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,41 +2,48 @@ version: 2.1
 
 executors:
   py35:
-    docker: [image: python:3.5-slim]
+    docker: [image: circleci/python:3.5]
   py36:
-    docker: [image: python:3.6-slim]
-  py37:
-    docker: [image: python:3.7-slim]
+    docker: [image: circleci/python:3.6]
+  py37: &default
+    docker: [image: circleci/python:3.7]
+  default: *default
 
 workflows:
   version: 2
   test:
     jobs:
-      - test-35
-      - test-36
-      - test-37
+      - test:
+          python-version: py35
+          name: test-35
+      - test:
+          python-version: py36
+          name: test-36
+      - test:
+          python-version: py37
+          name: test-37
   lint:
     jobs:
       - lint
 
 jobs:
-  test-35:
-    executor: py35
+  test:
+    parameters:
+      python-version:
+        type: string
+        enum: [py35, py36, py37]
+    executor: '<<parameters.python-version>>'
     steps:
       - checkout
       - test
-  test-36:
-    executor: py36
-    steps:
-      - checkout
-      - test
-  test-37:
-    executor: py37
-    steps:
-      - checkout
-      - test
+    environment:
+      # This is a regex pattern that allows us to target a specific python version.
+      # Annoyingly, Circle bundles python 3.7 with all of their python images.
+      # regex amounts to '^(?!py37.*$).*'. This is a bit backwards, since we need to
+      # do a double negative (skip, instead of include).
+      TOX_SKIP_ENV: '^(?!<<parameters.python-version>>.*$).*'
   lint:
-    executor: py37
+    executor: default
     steps:
       - checkout
       - lint
@@ -44,17 +51,19 @@ jobs:
 commands:
   setup:
     steps:
-      - run: pip install -U pip wheel setuptools tox flit
+      - run: pip install --user -U pip wheel setuptools tox flit
   install-local:
     steps:
       - run: make install
   tox:
     steps:
       - run: tox --skip-missing-interpreters
+
   test:
     steps:
       - setup
       - tox
+
   lint:
     steps:
       - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,62 @@
+version: 2.1
+
+executors:
+  py35:
+    docker: [image: python:3.5-slim]
+  py36:
+    docker: [image: python:3.6-slim]
+  py37:
+    docker: [image: python:3.7-slim]
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test-35
+      - test-36
+      - test-37
+  lint:
+    jobs:
+      - lint
+
+jobs:
+  test-35:
+    executor: py35
+    steps:
+      - checkout
+      - test
+  test-36:
+    executor: py36
+    steps:
+      - checkout
+      - test
+  test-37:
+    executor: py37
+    steps:
+      - checkout
+      - test
+  lint:
+    executor: py37
+    steps:
+      - checkout
+      - lint
+
+commands:
+  setup:
+    steps:
+      - run: pip install -U pip wheel setuptools tox flit
+  install-local:
+    steps:
+      - run: make install
+  tox:
+    steps:
+      - run: tox --skip-missing-interpreters
+  test:
+    steps:
+      - setup
+      - tox
+  lint:
+    steps:
+      - setup
+      - install-local
+      - run: make lint

--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,11 @@ lint:
 	black --check $(SRC_DIRS) tests
 	@# don't run mypy on the tests, since it doesn't work well with pytest yet
 	mypy $(SRC_DIRS)
+
+##@ Publishing
+
+# We default to the Test PyPI, to avoid publishing accidentally.
+PYPI_INDEX_NAME ?= testpypi
+
+publish:
+	flit --repository  '$(PYPI_INDEX_NAME)' publish

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ flit-install:
 
 pyenv-rehash:
 	@# as we don't use pip, we have to manually rehash the environment.
-	command -v pyenv && pyenv rehash
+	command -v pyenv && pyenv rehash ||:
 
 ##@ Code Checks
 

--- a/README.md
+++ b/README.md
@@ -124,3 +124,29 @@ The bulk of the linting can be adhered to by running `make autofix`.
 
 You can lint your code by running `make lint`.
 
+## Publishing
+
+We use [flit][flit] for publishing to the PyPI.
+
+By default, we publish to the test PyPI. This is to prevent accidental publishing.
+
+You need to configure your `~/.pypirc` file. An example is:
+
+```ini
+[distutils]
+index-servers =
+   pypi
+   testpypi
+
+[pypi]
+repository = https://upload.pypi.org/legacy/
+
+[testpypi]
+repository = https://test.pypi.org/legacy/
+```
+
+To do an actual publish, run `PYPI_INDEX_NAME=pypi make publish`.
+This will guide you through the process.
+
+
+[flit]: https://flit.readthedocs.io/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,15 @@ build-backend = "flit.buildapi"
 
 [tool.flit.metadata]
 module = "bluejay"
+dist-name = "fundingoptions-bluejay"
 author = "Funding Options"
 author-email = "techsupport@fundingoptions.com"
-classifiers = ["License :: OSI Approved :: MIT License"]
+home-page = "https://github.com/FundingOptions/bluejay-client"
+description-file = "README.md"
+
+classifiers = [
+    "License :: OSI Approved :: MIT License"
+]
 
 requires-python = '>=3.5'
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skipsdist = True
 deps =
     flit
 commands =
-    flit install --pth-file --deps production --extras test
+    flit install --pth-file --deps production --extras test,sns
     make test
 whitelist_externals =
     make


### PR DESCRIPTION
Tests are run across Python 3.5 - 3.7.

Linting is run on Python 3.7.

This also includes the publishing instructions, however we'll add Circle publishing at a later point