### PR TITLE
Ensure we build before publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,15 @@ lint:
 
 # We default to the Test PyPI, to avoid publishing accidentally.
 PYPI_INDEX_NAME ?= testpypi
+build_date := $(shell git show -s --format=%ct HEAD)
 
-publish:
+_set_date:
+	@# Set the date to be that of the last commit, to make our builds reproducible
+	@# https://flit.readthedocs.io/en/latest/reproducible.html
+	$(eval export SOURCE_DATE_EPOCH=$(build_date))
+
+build: _set_date
+	flit build
+
+publish: _set_date build
 	flit --repository  '$(PYPI_INDEX_NAME)' publish

--- a/bluejay/__init__.py
+++ b/bluejay/__init__.py
@@ -7,7 +7,7 @@ Currently supports:
 - Stdout (via Logging)
 """
 
-__version__ = "0.1"
+__version__ = "0.1.1"
 
 from . import backend, client, event
 


### PR DESCRIPTION
This ensures we have reproducible builds, and that we are building before publishing.

Flit deals with checking for unexpected files using the VCS integration