### PR TITLE
Remove JSON formatting flag on sent request

### DIFF
--- a/bluejay/backend/sns.py
+++ b/bluejay/backend/sns.py
@@ -30,7 +30,6 @@ class SNSBackend:
         compressed_payload = self.compress(payload)
         self.client.publish(
             TopicArn=self.topic_arn,
-            MessageStructure="json",
             Subject=message.event_name,
             Message=compressed_payload,
         )

--- a/tests/backend/sns/test_sending.py
+++ b/tests/backend/sns/test_sending.py
@@ -28,12 +28,7 @@ def test_backend_takes_a_SendEvent_command(
     sns_stub.add_response(
         "publish",
         {"MessageId": faker.pystr()},
-        {
-            "TopicArn": topic_arn,
-            "Message": expected_json,
-            "Subject": expected_subject,
-            "MessageStructure": "json",
-        },
+        {"TopicArn": topic_arn, "Message": expected_json, "Subject": expected_subject,},
     )
     result = backend.send(send_event_command)
     assert result.success is True


### PR DESCRIPTION
Additional argument was causing SNS to fail as we are no longer sending JSON in our request.